### PR TITLE
Configure Webmock for Nager API

### DIFF
--- a/app/poros/holiday.rb
+++ b/app/poros/holiday.rb
@@ -3,6 +3,6 @@ class Holiday
 
   def initialize(data)
     @date = data[:date]
-    @name = data[:name]
+    @name = data[:localName]
   end
 end

--- a/spec/features/merchant/bulk_discounts/index_spec.rb
+++ b/spec/features/merchant/bulk_discounts/index_spec.rb
@@ -88,21 +88,22 @@ RSpec.describe 'Merchant Bulk Discounts Index Page', type: :feature do
         expect(page).to have_content("Upcoming Holidays")
 
         within "#holiday-1" do
-          expect(page).to have_content("Name:")
-          expect(page).to have_content("Date:")
+          expect(page).to have_content("Name: Memorial Day")
+          expect(page).to have_content("Date: Monday, May 29, 2023")
         end
 
         within "#holiday-2" do
-          expect(page).to have_content("Name:")
-          expect(page).to have_content("Date:")
+          expect(page).to have_content("Name: Juneteenth")
+          expect(page).to have_content("Date: Monday, June 19, 2023")
         end
 
         within "#holiday-3" do
-          expect(page).to have_content("Name:")
-          expect(page).to have_content("Date:")
+          expect(page).to have_content("Name: Independence Day")
+          expect(page).to have_content("Date: Tuesday, July 04, 2023")
         end
 
         expect(page).to_not have_css("holiday-4")
+        expect(page).to_not have_content("Name: Labor Day")
       end
     end
   end

--- a/spec/fixtures/mock_responses.rb
+++ b/spec/fixtures/mock_responses.rb
@@ -66,4 +66,31 @@ module MockResponses
     "height": 3927,
     "likes": 235
   }.freeze
+
+  HOLIDAY_RESPONSE = [
+    {
+      "date": "2023-05-29",
+      "localName": "Memorial Day",
+      "name": "Memorial Day",
+      "countryCode": "US"
+    },
+    {
+      "date": "2023-06-19",
+      "localName": "Juneteenth",
+      "name": "Juneteenth",
+      "countryCode": "US"
+    },
+    {
+      "date": "2023-07-04",
+      "localName": "Independence Day",
+      "name": "Independence Day",
+      "countryCode": "US"
+    },
+    {
+      "date": "2023-09-04",
+      "localName": "Labor Day",
+      "name": "Labour Day",
+      "countryCode": "US"
+    }
+  ].freeze
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,7 +47,7 @@ end
 
 RSpec.configure do |config|
   config.before(:each) do
-    WebMock.disable_net_connect!(allow: 'https://date.nager.at')
+    # WebMock.disable_net_connect!(allow: 'https://date.nager.at')
 
     api_key = Rails.application.config.unsplash_api_key
 
@@ -59,16 +59,23 @@ RSpec.configure do |config|
       })
     .to_return(status: 200, body: LOGO_PHOTO_RESPONSE.to_json)
 
-    stub_request(:get, "https://api.unsplash.com/photos/random/?client_id=#{api_key}").to_return(status: 200, body: RANDOM_PHOTO_RESPONSE.to_json)
+    stub_request(:get, "https://api.unsplash.com/photos/random/?client_id=#{api_key}")
+    .to_return(status: 200, body: RANDOM_PHOTO_RESPONSE.to_json)
 
     search_term = "Dog"
-    stub_request(:get, "https://api.unsplash.com/search/photos?client_id=#{api_key}&page=1&query=#{search_term}").to_return(status: 200, body: SEARCH_PHOTO_RESPONSE.to_json)
+    stub_request(:get, "https://api.unsplash.com/search/photos?client_id=#{api_key}&page=1&query=#{search_term}")
+    .to_return(status: 200, body: SEARCH_PHOTO_RESPONSE.to_json)
 
     search_term = "Assumenda%20Animi"
     stub_request(:get, "https://api.unsplash.com/search/photos?page=1&query=#{search_term}&client_id=#{api_key}")
     .to_return(status: 200, body: SEARCH_NOT_FOUND_RESPONSE.to_json)
 
-    stub_request(:get, "https://api.unsplash.com/photos/Hl_o1K6OPsA/?client_id=#{api_key}").to_return(status: 200, body: ERROR_PHOTO_RESPONSE.to_json)
+    stub_request(:get, "https://api.unsplash.com/photos/Hl_o1K6OPsA/?client_id=#{api_key}")
+    .to_return(status: 200, body: ERROR_PHOTO_RESPONSE.to_json)
+
+    country_code = 'US'
+    stub_request(:get, "https://date.nager.at/api/v3/NextPublicHolidays/#{country_code}")
+    .to_return(status: 200, body: HOLIDAY_RESPONSE.to_json)
   end
 
   config.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
This PR sets up the Webmock gem to stub requests to the Nager Date API, specifically a call to the Next Public Holidays URL. 

I have saved a response with four holidays as a constant to help test that only three will be displayed on the page per the requirements for User Story 9.  I removed (commented out) the line of code that allows real API calls to be made to this API in test, as they are now replaced with the stubbed calls.

I made a minor tweak to the Holiday PORO to set the `name` variable to the `local name` variable in the parsed API response data, instead of the standard name.

All tests are passing, SimpleCov coverage for features and models at 100%.