### PR TITLE
Fix Invoice Show Pages (Merchant + Admin)

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,18 +10,6 @@ class Item < ApplicationRecord
   validates :description, presence: true
   validates :unit_price, presence: true, numericality: true
 
-  def find_sold_price(invoice)
-    invoice_items.where(invoice_id: invoice.id).pluck(:unit_price)
-  end
-
-  def quantity_sold(invoice)
-    invoice_items.where(invoice_id: invoice.id).pluck(:quantity)
-  end
-
-  def invoice_item_status(invoice)
-    invoice_items.where(invoice_id: invoice.id).pluck(:status)
-  end
-
   def paid_invoices
     invoices.joins(:transactions).where(transactions: {result: "success"})
   end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,22 +1,35 @@
 <%= render "shared/admin_header" %>
 
 <div id = "<%=@invoice.id%>_id">
-  <div class="center-header"><p>Invoice ID: <%= @invoice.id %></p></div>
-  <p>Invoice Status: <%= form_with model: @invoice, local: true do |form| %></p>
-                    <%= form.collection_select :status, ["In Progress", "Completed", "Cancelled"], :to_s, :titleize, selected: @invoice.status %>
-                    <%= form.submit "Update Invoice Status"%>
-                    <% end %>
-  <p>Invoice Created At: <%= format_date(@invoice.created_at) %></p>
-  <p>Total Revenue: <%= format_currency(@invoice.total_revenue) %></p>
-  <p>Total Discounted Revenue: <%= format_currency(@invoice.total_discounted_revenue) %></p>
-  <p>Customer Name: <%= "#{@invoice.customer_name}" %></p>
-  <p>Items: <% @invoice.items.each do |i| %></p>
-              <ul id = "item_<%=i.id%>">
-              <p>ID:<%= i.id %></p>
-              <li>Item name: <%= i.name %></li>
-              <li>Quantity Ordered: <%= format_item_info(i.quantity_sold(@invoice)) %></li>
-              <li>Item sold price: <%= format_currency(format_item_info(i.find_sold_price(@invoice))) %></li>
-              <li>Invoice Item status:  <%= format_item_info(i.invoice_item_status(@invoice)) %></li>
-              </ul>
-            <% end %>
+  <h3 class="center-header">Invoice #<%= @invoice.id %></h3>
+  <div class='flex-parent'>
+
+    <div class='flex-child'>
+      <p><b>Created on: </b><%= format_date(@invoice.created_at) %></p>
+      <p><b>Total Revenue: </b><%= format_currency(@invoice.total_revenue) %></p>
+      <p><b>Total Discounted Revenue: </b><%= format_currency(@invoice.total_discounted_revenue) %></p>
+      <p><b>Customer: </b><%= "#{@invoice.customer_name}" %></p>
+    </div>
+
+    <div class='flex-child'>
+      <p><b>Invoice Status:</b></p>
+        <%= form_with model: @invoice, local: true do |form| %>
+        <%= form.collection_select :status, ["In Progress", "Completed", "Cancelled"], :to_s, :titleize, selected: @invoice.status %>
+        <%= form.submit "Update Invoice Status"%>
+        <% end %>
+    </div>
+  </div>
 </div>
+
+  <h3 class="center-header">Items on this Invoice:</h3>
+
+  <% @invoice.invoice_items.each do |invoice_item| %>
+    <div id = "item_<%=invoice_item.id%>">
+      <p><b>Item name: </b><%= invoice_item.item.name %></p>
+      <ul>
+        <li><b>Quantity ordered: </b><%= invoice_item.quantity %></li>
+        <li><b>Price at sale: </b><%= format_currency(invoice_item.unit_price) %></li>
+        <li><b>Item order status: </b><%= format_item_info(invoice_item.status) %></li>
+      </ul>
+    </div>
+  <% end %>

--- a/app/views/merchant/invoices/show.html.erb
+++ b/app/views/merchant/invoices/show.html.erb
@@ -2,33 +2,35 @@
 
 <div id="invoice-info">
   <h3 class="center-header">Invoice #<%= @invoice.id %></h3>
-  <p>Status: <%= @invoice.status %></p>
-  <p>Created on: <%= format_date(@invoice.created_at) %></p>
-  <p>Total Revenue: <%= format_currency(@invoice.total_revenue_for_merchant(@merchant.id)) %></p>
-  <p>Total Discounted Revenue: <%= format_currency(@invoice.total_discounted_revenue_for_merchant(@merchant.id)) %></p>
+  <p><b>Status: </b><%= @invoice.status %></p>
+  <p><b>Created on: </b><%= format_date(@invoice.created_at) %></p>
+  <p><b>Total Revenue: </b><%= format_currency(@invoice.total_revenue_for_merchant(@merchant.id)) %></p>
+  <p><b>Total Discounted Revenue: </b><%= format_currency(@invoice.total_discounted_revenue_for_merchant(@merchant.id)) %></p>
 </div>
 
 <div id="customer-info">
-  <h3>Customer:</h3>
-  <p><%= @invoice.customer_name %></p>
+  <p><b>Customer: </b><%= @invoice.customer_name %></p>
 </div>
 
-<h3>Items on this Invoice:</h3>
-<% @invoice.merchant_items(@merchant.id).each do |invoice_item| %>
-  <div id="item-info-<%= invoice_item.item.id %>">
-    <p><b>Item Name:</b> <%= invoice_item.item.name %> |
-      <% if invoice_item.discount_applied? %>
-        <%= link_to "Discount Applied", merchant_bulk_discount_path(@merchant, invoice_item.get_discount_id) %>
-      <% else %>
-        No discount applied.
-      <% end %>
-    </p>
-    <p>Quantity: <%= format_item_info(invoice_item.item.quantity_sold(@invoice)) %></p>
-    <p>Unit Price: <%= format_currency(format_item_info(invoice_item.item.find_sold_price(@invoice))) %></p>
-    <p>Status: <%= format_item_info(invoice_item.item.invoice_item_status(@invoice)) %></p>
+<h3 class='center-header'>Items on this Invoice:</h3>
 
-    <div id="selector">
-      <p>Update Invoice Item Status</p>
+<% @invoice.merchant_items(@merchant.id).each do |invoice_item| %>
+  <div id="item-info-<%= invoice_item.item.id %>" class='flex-parent'>
+    <div class='flex-child'>
+      <p><b>Item Name:</b> <%= invoice_item.item.name %> |
+        <% if invoice_item.discount_applied? %>
+          <%= link_to "Discount Applied", merchant_bulk_discount_path(@merchant, invoice_item.get_discount_id) %>
+        <% else %>
+          No discount applied.
+        <% end %>
+      </p>
+      <p><b>Quantity: </b><%= invoice_item.quantity %></p>
+      <p><b>Unit Price: </b><%= format_currency(invoice_item.unit_price) %></p>
+      <p><b>Status: </b><%= format_item_info(invoice_item.status) %></p>
+    </div>
+
+    <div id="selector" class='flex-child'>
+      <h4>Update Item Status</h4>
       <%= form_with model: invoice_item, url: invoice_item_path(invoice_item), method: :patch, local: true do |form| %>
         <%= form.select :status, ['Pending', 'Packaged', 'Shipped'], selected: invoice_item.status %>
         <%= form.submit "Update Item Status" %>

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -30,25 +30,25 @@ RSpec.describe 'Admin Invoices Index Page', type: :feature do
     it "displays all information related to that invoice" do
       visit admin_invoice_path(@invoice_1)
       within("##{@invoice_1.id}_id") do
-        expect(page).to have_content("Invoice ID: #{@invoice_1.id}")
+        expect(page).to have_content("Invoice ##{@invoice_1.id}")
         expect(page).to have_content("Invoice Status:")
         expect(page).to have_field('invoice_status', with: "#{@invoice_1.status}")
-        expect(page).to have_content("Invoice Created At: #{format_date(@invoice_1.created_at)}")
-        expect(page).to have_content("Customer Name: #{@invoice_1.customer.first_name} #{@invoice_1.customer.last_name}")
+        expect(page).to have_content("Created on: #{format_date(@invoice_1.created_at)}")
+        expect(page).to have_content("Customer: #{@invoice_1.customer.first_name} #{@invoice_1.customer.last_name}")
 
-        expect(page).to_not have_content("Invoice ID: #{@invoice_2.id}")
-        expect(page).to_not have_content("Customer Name: #{@invoice_2.customer.first_name} #{@invoice_2.customer.last_name}")
+        expect(page).to_not have_content("Invoice ##{@invoice_2.id}")
+        expect(page).to_not have_content("Customer: #{@invoice_2.customer.first_name} #{@invoice_2.customer.last_name}")
       end
 
       visit admin_invoice_path(@invoice_2)
       within("##{@invoice_2.id}_id") do
-        expect(page).to have_content("Invoice ID: #{@invoice_2.id}")
+        expect(page).to have_content("Invoice ##{@invoice_2.id}")
         expect(page).to have_content("Invoice Status:")
-        expect(page).to have_content("Invoice Created At: #{format_date(@invoice_2.created_at)}")
-        expect(page).to have_content("Customer Name: #{@invoice_2.customer.first_name} #{@invoice_2.customer.last_name}")
+        expect(page).to have_content("Created on: #{format_date(@invoice_2.created_at)}")
+        expect(page).to have_content("Customer: #{@invoice_2.customer.first_name} #{@invoice_2.customer.last_name}")
 
-        expect(page).to_not have_content("Invoice ID: #{@invoice_1.id}")
-        expect(page).to_not have_content("Customer Name: #{@invoice_1.customer.first_name} #{@invoice_1.customer.last_name}")
+        expect(page).to_not have_content("Invoice ##{@invoice_1.id}")
+        expect(page).to_not have_content("Customer: #{@invoice_1.customer.first_name} #{@invoice_1.customer.last_name}")
       end
     end
   end
@@ -56,62 +56,57 @@ RSpec.describe 'Admin Invoices Index Page', type: :feature do
   describe "Admin Invoice Show Page: Invoice Item Information (User Story 34)" do
     it "displays all items on the invoice" do
       visit admin_invoice_path(@invoice_1)
-      within ("##{@invoice_1.id}_id") do
-        expect(page).to have_content("Item name: #{@item_1.name}")
-        expect(page).to have_content("Item name: #{@item_2.name}")
-
-        expect(page).to_not have_content(@item_3.name)
-      end
+      expect(page).to have_content("Item name: #{@item_1.name}")
+      expect(page).to have_content("Item name: #{@item_2.name}")
+      expect(page).to_not have_content(@item_3.name)
 
       visit admin_invoice_path(@invoice_2)
-      within ("##{@invoice_2.id}_id") do
-        expect(page).to have_content("Item name: #{@item_1.name}")
-        expect(page).to have_content("Item name: #{@item_3.name}")
+      expect(page).to have_content("Item name: #{@item_1.name}")
+      expect(page).to have_content("Item name: #{@item_3.name}")
+      expect(page).to_not have_content(@item_2.name)
 
-        expect(page).to_not have_content(@item_2.name)
-      end
     end
 
-    it "displays item name, quantity ordered, price sold, and Invoice Item status" do
+    it "displays item name, quantity ordered, price sold, and invoice item status" do
       visit admin_invoice_path(@invoice_1)
 
-      within("#item_#{@item_1.id}") do
-        expect(page).to have_content("Quantity Ordered: #{@invoice_item_1.quantity}")
-        expect(page).to have_content("Item sold price: #{format_currency(@invoice_item_1.unit_price)}")
-        expect(page).to have_content("Invoice Item status: #{@invoice_item_1.status}")
+      within("#item_#{@invoice_item_1.id}") do
+        expect(page).to have_content("Quantity ordered: #{@invoice_item_1.quantity}")
+        expect(page).to have_content("Price at sale: #{format_currency(@invoice_item_1.unit_price)}")
+        expect(page).to have_content("Item order status: #{@invoice_item_1.status}")
 
         expect(page).to_not have_content("Item name: #{@item_2.name}")
-        expect(page).to_not have_content("Item sold price: #{format_currency(@invoice_item_2.unit_price)}")
+        expect(page).to_not have_content("Price at sale: #{format_currency(@invoice_item_2.unit_price)}")
       end
 
-      within("#item_#{@item_2.id}") do
-        expect(page).to have_content("Quantity Ordered: #{@invoice_item_2.quantity}")
-        expect(page).to have_content("Item sold price: #{format_currency(@invoice_item_2.unit_price)}")
-        expect(page).to have_content("Invoice Item status: #{@invoice_item_2.status}")
+      within("#item_#{@invoice_item_2.id}") do
+        expect(page).to have_content("Quantity ordered: #{@invoice_item_2.quantity}")
+        expect(page).to have_content("Price at sale: #{format_currency(@invoice_item_2.unit_price)}")
+        expect(page).to have_content("Item order status: #{@invoice_item_2.status}")
 
         expect(page).to_not have_content("Item name: #{@item_1.name}")
-        expect(page).to_not have_content("Item sold price: #{format_currency(@invoice_item_1.unit_price)}")
+        expect(page).to_not have_content("Price at sale: #{format_currency(@invoice_item_1.unit_price)}")
       end
 
       visit admin_invoice_path(@invoice_2)
-      within("#item_#{@item_1.id}") do
-        expect(page).to have_content("Quantity Ordered: #{@invoice_item_3.quantity}")
-        expect(page).to have_content("Item sold price: #{format_currency(@invoice_item_3.unit_price)}")
-        expect(page).to have_content("Invoice Item status: #{@invoice_item_3.status}")
+      within("#item_#{@invoice_item_3.id}") do
+        expect(page).to have_content("Quantity ordered: #{@invoice_item_3.quantity}")
+        expect(page).to have_content("Price at sale: #{format_currency(@invoice_item_3.unit_price)}")
+        expect(page).to have_content("Item order status: #{@invoice_item_3.status}")
 
         expect(page).to_not have_content("Item name: #{@item_3.name}")
-        expect(page).to_not have_content("Quantity Ordered: #{@invoice_item_4.quantity}")
-        expect(page).to_not have_content("Item sold price: #{format_currency(@invoice_item_4.unit_price)}")
+        expect(page).to_not have_content("Quantity ordered: #{@invoice_item_4.quantity}")
+        expect(page).to_not have_content("Price at sale: #{format_currency(@invoice_item_4.unit_price)}")
       end
 
-      within("#item_#{@item_3.id}") do
-        expect(page).to have_content("Quantity Ordered: #{@invoice_item_4.quantity}")
-        expect(page).to have_content("Item sold price: #{format_currency(@invoice_item_4.unit_price)}")
-        expect(page).to have_content("Invoice Item status: #{@invoice_item_4.status}")
+      within("#item_#{@invoice_item_4.id}") do
+        expect(page).to have_content("Quantity ordered: #{@invoice_item_4.quantity}")
+        expect(page).to have_content("Price at sale: #{format_currency(@invoice_item_4.unit_price)}")
+        expect(page).to have_content("Item order status: #{@invoice_item_4.status}")
 
         expect(page).to_not have_content("Item name: #{@item_1.name}")
-        expect(page).to_not have_content("Quantity Ordered: #{@invoice_item_3.quantity}")
-        expect(page).to_not have_content("Item sold price: #{format_currency(@invoice_item_3.unit_price)}")
+        expect(page).to_not have_content("Quantity ordered: #{@invoice_item_3.quantity}")
+        expect(page).to_not have_content("Price at sale: #{format_currency(@invoice_item_3.unit_price)}")
       end
     end
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -36,30 +36,6 @@ RSpec.describe Item, type: :model do
       @transaction_2 = create(:transaction, invoice_id: @invoice_2.id, result: true)
     end
 
-    describe "#find_sold_price" do
-      it "finds the price the item sold for in a particular invoice_item" do
-        expect(@item_1.find_sold_price(@invoice_1)).to eq([@invoice_item_1.unit_price])
-        expect(@item_2.find_sold_price(@invoice_1)).to eq([@invoice_item_2.unit_price])
-        expect(@item_1.find_sold_price(@invoice_2)).to eq([@invoice_item_3.unit_price])
-      end
-    end
-
-    describe "#quantity_sold" do
-      it "finds the quantity of the item sold in a particular invoice_item" do
-        expect(@item_1.quantity_sold(@invoice_1)).to eq([@invoice_item_1.quantity])
-        expect(@item_2.quantity_sold(@invoice_1)).to eq([@invoice_item_2.quantity])
-        expect(@item_1.quantity_sold(@invoice_2)).to eq([@invoice_item_3.quantity])
-      end
-    end
-
-    describe "#invoice_item_status" do
-      it "finds the status of the item in a particular invoice_item" do
-        expect(@item_1.invoice_item_status(@invoice_1)).to eq([@invoice_item_1.status])
-        expect(@item_2.invoice_item_status(@invoice_1)).to eq([@invoice_item_2.status])
-        expect(@item_1.invoice_item_status(@invoice_2)).to eq([@invoice_item_3.status])
-      end
-    end
-
     describe "#paid_invoices" do
       it "finds all paid invoices for an item" do
         expect(@item_1.paid_invoices).to eq([@invoice_1, @invoice_2])


### PR DESCRIPTION
This PR fixes an issue with the Merchant and Admin invoice show pages, causing the display to collapse items that are ordered twice but have different quantities, possibly prices, and statuses.

Along with this, I have removed three instance methods that are not needed to render data in the view to simplify logic in these files, and more directly access item attributes.

SimpleCov indicates 100% test coverage for features and models, all tests are passing after this refactor.