### PR TITLE
Bulk Discount Create /  Edit Validity - Extension 3

### DIFF
--- a/app/controllers/merchant/bulk_discounts_controller.rb
+++ b/app/controllers/merchant/bulk_discounts_controller.rb
@@ -10,17 +10,12 @@ class Merchant::BulkDiscountsController < ApplicationController
   end
 
   def create
-    discount = BulkDiscount.new(bulk_discount_params.merge(merchant_id: @merchant.id))
+    @discount = BulkDiscount.new(bulk_discount_params.merge(merchant_id: @merchant.id))
     if invalid_discount?
       flash.now[:alert] = "Try again! You cannot create a discount that will not be applied."
       render :new
     else
-      if discount.save
-        redirect_to merchant_bulk_discounts_path(@merchant), notice: "Discount successfully added!"
-      else
-        flash.now[:alert] = "Error: #{error_message(discount.errors)}"
-        render :new
-      end
+      check_for_save
     end
   end
 
@@ -32,13 +27,7 @@ class Merchant::BulkDiscountsController < ApplicationController
 
   def update
     if attributes_changed?
-      if invalid_discount?
-        flash.now[:alert] = "Try again! The attempted update would make this discount invalid."
-        render :edit
-      else
-        @discount.update(bulk_discount_params)
-        redirect_to merchant_bulk_discount_path(@merchant, @discount), notice: "Discount successfully updated!"
-      end
+      check_edit_validity
     else
       flash.now[:alert] = "Error: You must update at least 1 field to continue."
       render :edit
@@ -75,5 +64,24 @@ class Merchant::BulkDiscountsController < ApplicationController
   def attributes_changed?
     (bulk_discount_params[:percentage].to_i != @discount.percentage) ||
     (bulk_discount_params[:threshold_quantity].to_i != @discount.threshold_quantity)
+  end
+
+  def check_for_save
+    if @discount.save
+      redirect_to merchant_bulk_discounts_path(@merchant), notice: "Discount successfully added!"
+    else
+      flash.now[:alert] = "Error: #{error_message(@discount.errors)}"
+      render :new
+    end
+  end
+
+  def check_edit_validity
+    if invalid_discount?
+      flash.now[:alert] = "Try again! The attempted update would make this discount invalid."
+      render :edit
+    else
+      @discount.update(bulk_discount_params)
+      redirect_to merchant_bulk_discount_path(@merchant, @discount), notice: "Discount successfully updated!"
+    end
   end
 end

--- a/app/controllers/merchant/bulk_discounts_controller.rb
+++ b/app/controllers/merchant/bulk_discounts_controller.rb
@@ -11,16 +11,16 @@ class Merchant::BulkDiscountsController < ApplicationController
 
   def create
     discount = BulkDiscount.new(bulk_discount_params.merge(merchant_id: @merchant.id))
-    if valid_discount?
+    if invalid_discount?
+      flash.now[:alert] = "Try again! You cannot create a discount that will not be applied."
+      render :new
+    else
       if discount.save
         redirect_to merchant_bulk_discounts_path(@merchant), notice: "Discount successfully added!"
       else
         flash.now[:alert] = "Error: #{error_message(discount.errors)}"
         render :new
       end
-    else
-      flash.now[:alert] = "Try again! You cannot create a discount that will not be applied."
-      render :new
     end
   end
 
@@ -32,8 +32,13 @@ class Merchant::BulkDiscountsController < ApplicationController
 
   def update
     if attributes_changed?
-      @discount.update(bulk_discount_params)
-      redirect_to merchant_bulk_discount_path(@merchant, @discount), notice: "Discount successfully updated!"
+      if invalid_discount?
+        flash.now[:alert] = "Try again! The attempted update would make this discount invalid."
+        render :edit
+      else
+        @discount.update(bulk_discount_params)
+        redirect_to merchant_bulk_discount_path(@merchant, @discount), notice: "Discount successfully updated!"
+      end
     else
       flash.now[:alert] = "Error: You must update at least 1 field to continue."
       render :edit
@@ -58,13 +63,13 @@ class Merchant::BulkDiscountsController < ApplicationController
     params.require(:bulk_discount).permit(:percentage, :threshold_quantity)
   end
 
-  def valid_discount?
+  def invalid_discount?
     current_discount = @merchant.lowest_quantity_discount
     current_percentage = current_discount.percentage
     current_quantity = current_discount.threshold_quantity
 
-    (bulk_discount_params[:percentage].to_i > current_percentage) ||
-    (bulk_discount_params[:threshold_quantity].to_i < current_quantity)
+    (bulk_discount_params[:percentage].to_i < current_percentage) &&
+    (bulk_discount_params[:threshold_quantity].to_i >= current_quantity)
   end
 
   def attributes_changed?

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -60,4 +60,8 @@ class Merchant < ApplicationRecord
   def top_five_items_by_revenue
     items.joins(:transactions).select("items.*, SUM(invoice_items.unit_price * invoice_items.quantity) AS revenue").where(transactions: {result: "success"}).group("items.id").order(revenue: :desc).limit(5)
   end
+
+  def lowest_quantity_discount
+    bulk_discounts.order("threshold_quantity ASC, percentage DESC").first
+  end
 end

--- a/spec/features/merchant/bulk_discounts/edit_spec.rb
+++ b/spec/features/merchant/bulk_discounts/edit_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'Merchant Edit Bulk Discounts', type: :feature do
+  before(:each) do
+    @merchant_1 = create(:merchant)
+    @bulk_1 = create(:bulk_discount, percentage: 20, threshold_quantity: 10, merchant_id: @merchant_1.id)
+  end
+
+  describe 'Extension #3' do
+    it 'prevents merchants from editing a discount if they have discount(s) that would prevent the edited one from being applied' do
+      visit edit_merchant_bulk_discount_path(@merchant_1, @bulk_1)
+
+      fill_in :bulk_discount_percentage, with: 15
+      fill_in :bulk_discount_threshold_quantity, with: 10
+      click_button("Edit Discount")
+
+      expect(page).to have_content("Try again! The attempted update would make this discount invalid.")
+
+      visit edit_merchant_bulk_discount_path(@merchant_1, @bulk_1)
+
+      fill_in :bulk_discount_percentage, with: 25
+      fill_in :bulk_discount_threshold_quantity, with: 10
+      click_button("Edit Discount")
+
+      expect(page).to have_content("Discount successfully updated!")
+    end
+  end
+end

--- a/spec/features/merchant/bulk_discounts/new_spec.rb
+++ b/spec/features/merchant/bulk_discounts/new_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe 'Merchant New Bulk Discounts', type: :feature do
       fill_in :bulk_discount_threshold_quantity, with: 15
       click_button("Add Discount")
 
-      # expect(current_path).to eq(new_merchant_bulk_discount_path(@merchant_1))
       expect(page).to have_content("Try again! You cannot create a discount that will not be applied.")
     end
   end

--- a/spec/features/merchant/bulk_discounts/new_spec.rb
+++ b/spec/features/merchant/bulk_discounts/new_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe 'Merchant New Bulk Discounts', type: :feature do
+  before(:each) do
+    @merchant_1 = create(:merchant)
+    @bulk_1 = create(:bulk_discount, percentage: 20, threshold_quantity: 10, merchant_id: @merchant_1.id)
+  end
+
+  describe 'Extension #3' do
+    it 'prevents merchants from creating new discounts if they have discount(s) that would prevent the new one from being applied' do
+      visit new_merchant_bulk_discount_path(@merchant_1)
+
+      fill_in :bulk_discount_percentage, with: 15
+      fill_in :bulk_discount_threshold_quantity, with: 15
+      click_button("Add Discount")
+
+      # expect(current_path).to eq(new_merchant_bulk_discount_path(@merchant_1))
+      expect(page).to have_content("Try again! You cannot create a discount that will not be applied.")
+    end
+  end
+end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -215,6 +215,21 @@ RSpec.describe Merchant, type: :model do
           expect(@merchant_1.top_five_items_by_revenue).to eq([@item_1, @item_2, @item_3, @item_4, @item_5])
         end
       end
+
+      describe '#lowest_quantity_discount' do
+        it 'returns the bulk discount with the lowest quantity + highest percentage if a tie' do
+          @merchant_2 = create(:merchant)
+
+          @bulk_1 = create(:bulk_discount, percentage: 20, threshold_quantity: 10, merchant_id: @merchant_1.id)
+          @bulk_2 = create(:bulk_discount, percentage: 15, threshold_quantity: 5, merchant_id: @merchant_1.id)
+          @bulk_3 = create(:bulk_discount, percentage: 10, threshold_quantity: 2, merchant_id: @merchant_1.id)
+          @bulk_4 = create(:bulk_discount, percentage: 30, threshold_quantity: 2, merchant_id: @merchant_1.id)
+          @bulk_5 = create(:bulk_discount, percentage: 10, threshold_quantity: 1, merchant_id: @merchant_2.id)
+
+          expect(@merchant_1.lowest_quantity_discount).to eq(@bulk_4)
+          expect(@merchant_2.lowest_quantity_discount).to eq(@bulk_5)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR completes functionality listed in Extension 3, to ensure that merchants cannot create a new bulk discount (or edit an existing bulk discount) if the new / edited discount would not be utilized due to better discounts being available for that quantity of items.

I also refactored the controller logic in the Merchant / Bulk Discounts controller create and update methods to handle this using helper methods.

For a future refactor, I would like to see if I could remove some of the logic in this controller to the application_controller file.

Tests are passing at 100% coverage for both models and features per SimpleCov.